### PR TITLE
ADD: BALTRAD GoogleMapsPlugin ex Display

### DIFF
--- a/binder/install_baltrad_rave_gmap.sh
+++ b/binder/install_baltrad_rave_gmap.sh
@@ -3,37 +3,25 @@ set -x
 
 # Vagrant provision script for installing BALTRAD GoogleMapsPlugin component
 
-# dependencies
-#sudo apt-get install -qq libfreetype6-dev
-sudo apt-get install -qq apache2
-sudo apt-get install -qq php
-sudo apt-get install -qq libapache2-mod-php
-sudo cp /vagrant/vendor/etc/apache2/apache2.conf /etc/apache2/apache2.conf
-sudo cp /vagrant/vendor/etc/apache2/sites-enabled/000-default.conf /etc/apache2/sites-enabled/000-default.conf
+# dependencies removed in bare-bones provisioning
 
 # install GoogleMapsPlugin from source
-cd ~/tmp
+cd ~
+if [ ! -d tmp ]; then
+    mkdir tmp
+fi
+cd tmp
+
 git clone --depth=1 git://git.baltrad.eu/GoogleMapsPlugin.git
 cd GoogleMapsPlugin/
+
 source $CONDA_DIR/bin/activate $RADARENV
+export CONDA_PREFIX=/srv/conda/envs/notebook
 python setup.py install --prefix=$CONDA_PREFIX
+
 # Replace Google Maps with OpenStreetMap
 cp web/index.html $CONDA_PREFIX/rave_gmap/web/.
 rm $CONDA_PREFIX/rave_gmap/web/index.php
 
-# HACK the setup.py files need to add the line
-# import distutils.sysconfig
 # The .pth file is not copied because of this, manually create the file
-echo $CONDA_PREFIX/rave_gmap/Lib/ > $CONDA_PREFIX/lib/python3.6/site-packages/rave_gmap.pth
-
-# Add an amazing case!
-cp /vagrant/vendor/opt/baltrad/rave_gmap/web/smhi-areas.xml $CONDA_PREFIX/rave_gmap/web/.
-cp /vagrant/vendor/opt/baltrad/rave_gmap/web/products.js $CONDA_PREFIX/rave_gmap/web/.
-mkdir $CONDA_PREFIX/rave_gmap/web/data
-cp /vagrant/vendor/opt/baltrad/rave_gmap/web/data/cawkr_gmaps.tgz $CONDA_PREFIX/rave_gmap/web/data/.
-cd $CONDA_PREFIX/rave_gmap/web/data
-tar xzf cawkr_gmaps.tgz
-rm cawkr_gmaps.tgz
-
-# Restart apache2 with the plugin contents
-sudo service apache2 restart
+echo $CONDA_PREFIX/rave_gmap/Lib/ > $CONDA_PREFIX/lib/python3.7/site-packages/rave_gmap.pth

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -21,6 +21,7 @@ bash /home/jovyan/binder/install_baltrad_rave.sh
 bash /home/jovyan/binder/install_baltrad_beamb.sh
 bash /home/jovyan/binder/install_baltrad_bropo.sh
 bash /home/jovyan/binder/install_baltrad_wrwp.sh
+bash /home/jovyan/binder/install_baltrad_rave_gmap.sh
 bash /home/jovyan/binder/install_baltrad_short_course.sh
 cp /home/jovyan/binder/kernel.json $CONDA_PREFIX/share/jupyter/kernels/python3/.
 


### PR DESCRIPTION
Rudimentary GoogleMapsPlugin without the Display capabilities through the Apache2 service. 
This add-on is used for simpler visualization in the notebooks.
Web-display is still being scoped out.